### PR TITLE
Fix database lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@adonisjs/lucid",
+  "name": "@coddess-development/lucid",
   "version": "18.4.2",
-  "description": "SQL ORM built on top of Active Record pattern",
+  "description": "A Fork of AdonisJS Lucid ORM, which fixes inconvenient bugs",
   "engines": {
     "node": ">=14.15.4"
   },
@@ -40,14 +40,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/adonisjs/lucid.git"
+    "url": "git+https://github.com/coddess-development/coddess-lucid"
   },
   "author": "virk,adonisjs",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/adonisjs/lucid/issues"
   },
-  "homepage": "https://github.com/adonisjs/lucid#readme",
+  "homepage": "https://github.com/coddess-development/coddess-lucid#readme",
   "dependencies": {
     "@faker-js/faker": "^8.0.1",
     "@poppinss/hooks": "^5.0.3",
@@ -110,7 +110,7 @@
   },
   "publishConfig": {
     "tag": "latest",
-    "access": "public"
+    "access": "restricted"
   },
   "nyc": {
     "exclude": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coddess-development/lucid",
-  "version": "18.4.2",
+  "version": "18.4.2-coddess.0",
   "description": "A Fork of AdonisJS Lucid ORM, which fixes inconvenient bugs",
   "engines": {
     "node": ">=14.15.4"

--- a/src/Migrator/index.ts
+++ b/src/Migrator/index.ts
@@ -279,7 +279,8 @@ export class Migrator extends EventEmitter implements MigratorContract {
 
     const released = await this.client.dialect.releaseAdvisoryLock(1)
     if (!released) {
-      throw new Exception('Migration completed, but unable to release database lock')
+      // throw new Exception('Migration completed, but unable to release database lock')
+      console.error('Migration completed, but unable to release database lock')
     }
     this.emit('release:lock')
   }


### PR DESCRIPTION
Правим така, че неуспех за освобождаване на database lock да не хвърля грешка, а само да изкарва информативно съобщение.

Също така съм настроил (уж) package.json да е готов за release и съм обновил версията е в "наш" формат, който отговаря на semver стандарта.